### PR TITLE
Add ideal MixedModeConverter 4-port

### DIFF
--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -54,6 +54,7 @@ from pmrf.models.components.ideal import (
     Autotransformer as Autotransformer,
     Balun as Balun,
     SourceConverter as SourceConverter,
+    MixedModeConverter as MixedModeConverter,
     Isolator as Isolator,
     Splitter as Splitter,
     Tee as Tee,

--- a/pmrf/models/components/ideal.py
+++ b/pmrf/models/components/ideal.py
@@ -9,7 +9,8 @@ import equinox as eqx
 
 from pmrf.models import Model
 from pmrf.frequency import Frequency
-from pmrf.utils import field
+from pmrf.utils import error_if, field
+from pmrf.utils.rf import fix_z0_shape
 from pmrf.rf import renormalize_s
 from pmrf.types import ArrayLike
 from pmrf.parameters import Param, param
@@ -338,6 +339,106 @@ class SourceConverter(Model):
         s = jnp.tile(s_one, (freq.npoints, 1, 1))        
         return s
     
+
+def _require_equal_z0(x, z0: ArrayLike, nports: int, npoints: int):
+    """
+    Thread `x` through a runtime check that all `nports` reference impedances are equal.
+
+    Parameters
+    ----------
+    x : Any
+        The value to pass through, typically the S-parameter matrix being guarded.
+    z0 : ArrayLike
+        The reference impedance, in any shape accepted by :func:`pmrf.utils.rf.fix_z0_shape`.
+    nports : int
+        The number of ports.
+    npoints : int
+        The number of frequency points.
+
+    Returns
+    -------
+    Any
+        The unmodified input `x`.
+
+    Raises
+    ------
+    equinox.EquinoxRuntimeError
+        At runtime, if the ports do not all share the same reference impedance.
+    """
+    z0_arr = fix_z0_shape(z0, npoints, nports)
+    unequal = jnp.any(z0_arr != z0_arr[..., :1])
+
+    return error_if(
+        x,
+        unequal,
+        f"All {nports} reference impedances must be equal, got z0 = {{}}",
+        z0_arr,
+    )
+
+
+class MixedModeConverter(Model):
+    r"""
+    (experimental) An ideal, lossless, frequency-independent 4-port mixed-mode converter.
+
+    This component converts a pair of equal-impedance physical (single-ended) ports into
+    a power-normalized common-mode and differential-mode port pair, using the orthogonal
+    modal transform
+
+    .. math::
+
+        U = \frac{1}{\sqrt{2}} \begin{bmatrix} 1 & 1 \\ 1 & -1 \end{bmatrix}.
+
+    Port ordering:
+
+    - Port 1: physical (single-ended) port `p`
+    - Port 2: physical (single-ended) port `n`
+    - Port 3: common mode of ports 1 and 2
+    - Port 4: differential mode of ports 1 and 2
+
+    Writing the incident and reflected waves of the physical pair as
+    :math:`a_{12} = (a_1, a_2)^T` and :math:`b_{12} = (b_1, b_2)^T`, and likewise
+    :math:`a_{34} = (a_c, a_d)^T` for the modal pair, the converter enforces
+    :math:`b_{34} = U a_{12}` and :math:`b_{12} = U a_{34}`, so that
+
+    .. math::
+
+        S = \begin{bmatrix} 0 & U \\ U & 0 \end{bmatrix}.
+
+    Since :math:`U` is real, symmetric and orthogonal, `S` is symmetric (reciprocal) and
+    unitary (lossless), and all four ports are perfectly matched. The transform is its own
+    inverse, so cascading two converters back-to-back through the modal pair gives identity.
+
+    Because the modal waves are power-normalized, the modal ports carry the *same* wave
+    normalization as the physical ports: the usual :math:`Z_0/2` common-mode and
+    :math:`2 Z_0` differential-mode impedances are absorbed into the normalization. The
+    S-parameters are therefore constant across frequency and independent of the reference
+    impedance, provided every port shares the same reference impedance. This is validated
+    on evaluation.
+
+    Raises
+    ------
+    equinox.EquinoxRuntimeError
+        At runtime, if the four reference impedances passed to :meth:`s` are not all equal.
+    """
+    def s(self, freq: Frequency, z0: ArrayLike = 50.0) -> jnp.ndarray:
+        u = jnp.array([
+            [1.0,  1.0],
+            [1.0, -1.0],
+        ], dtype=jnp.complex128) / jnp.sqrt(2.0)
+
+        zeros = jnp.zeros((2, 2), dtype=jnp.complex128)
+
+        # The physical and modal pairs are each perfectly matched, and couple
+        # only to one another through the modal transform
+        s_mat = jnp.block([
+            [zeros, u],
+            [u, zeros],
+        ])
+
+        s_mat = jnp.broadcast_to(s_mat, (freq.npoints, 4, 4))
+
+        return _require_equal_z0(s_mat, z0, 4, freq.npoints)
+
 
 class Isolator(Model):
     """

--- a/tests/test_models/test_transformers.py
+++ b/tests/test_models/test_transformers.py
@@ -2,12 +2,13 @@ import pytest
 import numpy as np
 import jax
 import jax.numpy as jnp
+import equinox as eqx
 
 from pmrf.frequency import Frequency
 from pmrf.parameters import Unconstrained
 from pmrf.models import (
     Transformer, CentreTappedTransformer, Autotransformer, Balun,
-    SourceConverter, CoupledInductors, Inductor,
+    SourceConverter, MixedModeConverter, CoupledInductors, Inductor,
 )
 
 
@@ -176,3 +177,96 @@ def test_coupled_inductors_approach_ideal_transformer(basic_freq):
     ideal = Transformer(N=np.sqrt(L2 / L1))
 
     assert np.allclose(coupled.s(basic_freq), ideal.s(basic_freq), atol=1e-3)
+
+
+def cascade_through_modes(s_a, s_b, nmodal=2):
+    """Cascade two 4-ports by tying the last `nmodal` ports of each together."""
+    s_a, s_b = np.asarray(s_a), np.asarray(s_b)
+    p = slice(0, s_a.shape[0] - nmodal)
+    m = slice(s_a.shape[0] - nmodal, s_a.shape[0])
+    npp = s_a.shape[0] - nmodal
+
+    # Internal waves satisfy b_m = S_mp a_p + S_mm a_m, with a_m of one side the b_m of the other
+    lhs = np.block([
+        [np.eye(nmodal), -s_a[m, m]],
+        [-s_b[m, m], np.eye(nmodal)],
+    ])
+    rhs = np.block([
+        [s_a[m, p], np.zeros((nmodal, npp))],
+        [np.zeros((nmodal, npp)), s_b[m, p]],
+    ])
+    b_int = np.linalg.solve(lhs, rhs)
+
+    # External ports see their own reflection plus what returns from the interface
+    ext = np.block([
+        [s_a[p, p], np.zeros((npp, npp))],
+        [np.zeros((npp, npp)), s_b[p, p]],
+    ])
+    coupling = np.block([
+        [s_a[p, m], np.zeros((npp, nmodal))],
+        [np.zeros((npp, nmodal)), s_b[p, m]],
+    ])
+    return ext + coupling @ b_int[[*range(nmodal, 2 * nmodal), *range(nmodal)], :]
+
+
+def test_mixed_mode_converter_is_unitary_and_reciprocal(basic_freq):
+    """The converter is lossless, reciprocal and matched at every port."""
+    s = MixedModeConverter().s(basic_freq)
+
+    assert s.shape == (5, 4, 4)
+    assert_lossless_and_reciprocal(s[0])
+
+    # Both the physical and the modal pair are perfectly matched
+    assert np.allclose(s[0, :2, :2], 0.0)
+    assert np.allclose(s[0, 2:, 2:], 0.0)
+
+
+def test_mixed_mode_converter_modal_selectivity(basic_freq):
+    """Even excitation appears only at the common port, and odd only at the differential."""
+    s = np.asarray(MixedModeConverter().s(basic_freq)[0])
+    root2 = np.sqrt(2.0)
+
+    # Ports 1 and 2 driven in phase excite port 3 alone
+    b_even = s @ np.array([1.0, 1.0, 0.0, 0.0])
+    assert np.allclose(b_even, [0.0, 0.0, root2, 0.0])
+
+    # Ports 1 and 2 driven in antiphase excite port 4 alone
+    b_odd = s @ np.array([1.0, -1.0, 0.0, 0.0])
+    assert np.allclose(b_odd, [0.0, 0.0, 0.0, root2])
+
+    # Driving the common port drives the physical pair in phase, and vice versa
+    assert np.allclose(s @ np.array([0.0, 0.0, 1.0, 0.0]), [1 / root2, 1 / root2, 0.0, 0.0])
+    assert np.allclose(s @ np.array([0.0, 0.0, 0.0, 1.0]), [1 / root2, -1 / root2, 0.0, 0.0])
+
+
+def test_mixed_mode_converter_round_trip_is_identity(basic_freq):
+    """Two converters back-to-back through their modal ports form a through connection."""
+    s = MixedModeConverter().s(basic_freq)[0]
+    cascaded = cascade_through_modes(s, s)
+
+    expected = np.block([
+        [np.zeros((2, 2)), np.eye(2)],
+        [np.eye(2), np.zeros((2, 2))],
+    ])
+    assert np.allclose(cascaded, expected)
+
+
+def test_mixed_mode_converter_broadcasts_over_frequency():
+    """The S-parameters are frequency-independent but span the whole grid."""
+    freq = Frequency(start=0.1, stop=20.0, npoints=17, unit='GHz')
+    s = np.asarray(MixedModeConverter().s(freq))
+
+    assert s.shape == (17, 4, 4)
+    assert np.allclose(s, s[0])
+
+
+def test_mixed_mode_converter_requires_equal_reference_impedances(basic_freq):
+    """The modal transform is only power-normalized when every port shares one z0."""
+    model = MixedModeConverter()
+
+    # A single shared impedance is fine, whatever its value
+    assert np.allclose(model.s(basic_freq, z0=50.0), model.s(basic_freq, z0=75.0))
+    assert np.allclose(model.s(basic_freq, z0=[50.0] * 4), model.s(basic_freq, z0=50.0))
+
+    with pytest.raises(eqx.EquinoxRuntimeError, match="must be equal"):
+        model.s(basic_freq, z0=[50.0, 75.0, 50.0, 50.0])


### PR DESCRIPTION
Adds a reciprocal, lossless four-port that converts two equal-impedance physical ports into power-normalized common and differential ports via the orthogonal transform U = (1/sqrt(2))[[1, 1], [1, -1]].

Ports 1 and 2 are the physical (single-ended) pair, port 3 is the common mode and port 4 the differential mode. Since the modal waves are power normalized, all four ports share one wave normalization, so the matrix is frequency- and impedance-independent, and unequal port reference impedances are rejected at runtime via error_if.